### PR TITLE
speedup download of Xaml

### DIFF
--- a/Winget_LTSC_Installer.ps1
+++ b/Winget_LTSC_Installer.ps1
@@ -14,6 +14,7 @@ catch
 # Download XAML package
 try 
 {
+  $ProgressPreference = 'SilentlyContinue'
   Invoke-WebRequest -Uri "https://www.nuget.org/api/v2/package/Microsoft.UI.Xaml/2.8.6" -OutFile "microsoft.ui.xaml.2.8.6.zip" -ErrorAction Stop
 }
 catch


### PR DESCRIPTION
For some reason, Invoke-WebRequest is very slow when progress is showed, and all 19.5MB of the Xaml package take a very long time to download. Setting $ProgressPreference speeds up the download immensely. See: https://stackoverflow.com/questions/28682642/powershell-why-is-using-invoke-webrequest-much-slower-than-a-browser-download